### PR TITLE
Upgrade underscore - use arrow function

### DIFF
--- a/lib/infiniScroll.js
+++ b/lib/infiniScroll.js
@@ -195,7 +195,6 @@
 
     fetch: function() {
       var data = _.extend(this.getPaginationParams(), this.options.extraParams, this.options.getParams());
-      //console.log('fetching', data);
       this.pendingXhr = this.collection.fetch({
         success: this.fetchSuccess,
         remove: false,
@@ -204,9 +203,7 @@
 
       // clear this.pendingXhr whenever the request is done
       if (this.pendingXhr) {
-          this.pendingXhr.always(_(function() {
-              this.pendingXhr = false;
-          }).bind(this));
+          this.pendingXhr.always(() => this.pendingXhr = false);
       }
     },
 


### PR DESCRIPTION
Part of upgrading underscore to 1.12.1 (stable)

- Previous attempt to upgrade https://github.com/closeio/close-ui/pull/2238/files
- Reverted here https://github.com/closeio/close-ui/pull/2242/files

From the error info, it looks like the underscore _ is not recognized in infiniScroll package: https://github.com/closeio/infiniScroll.js#b81660340e8b2aa3c42f85dc98ed85fd1ed74537

The issue:
 <img width="615" alt="Screenshot 2021-08-04 at 11 13 52" src="https://user-images.githubusercontent.com/13134752/128146524-13be38b0-f982-498d-aefa-437f85c1bd26.png">

`_` is not a function, first tried to change the way underscore is injected (assumed it is not defined) - still having the issue when scrolling.


Tested it here https://github.com/closeio/close-ui/pull/2427