### PR TITLE
Do not fetch collection if scroll container is hidden

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/lib/infiniScroll.js
+++ b/lib/infiniScroll.js
@@ -1,41 +1,48 @@
-(function() {
-  'use strict';
+(function () {
+  "use strict";
 
   // https://github.com/slindberg/jquery-scrollparent/blob/master/jquery.scrollparent.js
   if (!jQuery.fn.scrollParent) {
-    jQuery.fn.scrollParent = function() {
-    var overflowRegex = /(auto|scroll)/,
-    position = this.css( "position" ),
-    excludeStaticParent = position === "absolute",
-    scrollParent = this.parents().filter( function() {
-      var parent = $( this );
-      if ( excludeStaticParent && parent.css( "position" ) === "static" ) {
-        return false;
-      }
-      return (overflowRegex).test( parent.css( "overflow" ) + parent.css( "overflow-y" ) + parent.css( "overflow-x" ) );
-    }).eq( 0 );
+    jQuery.fn.scrollParent = function () {
+      var overflowRegex = /(auto|scroll)/,
+        position = this.css("position"),
+        excludeStaticParent = position === "absolute",
+        scrollParent = this.parents()
+          .filter(function () {
+            var parent = $(this);
+            if (excludeStaticParent && parent.css("position") === "static") {
+              return false;
+            }
+            return overflowRegex.test(
+              parent.css("overflow") +
+                parent.css("overflow-y") +
+                parent.css("overflow-x")
+            );
+          })
+          .eq(0);
 
-    return position === "fixed" || !scrollParent.length ? $( this[ 0 ].ownerDocument || document ) : scrollParent;
+      return position === "fixed" || !scrollParent.length
+        ? $(this[0].ownerDocument || document)
+        : scrollParent;
     };
   }
 
-  Backbone.InfiniScroll = function(collection, options) {
+  Backbone.InfiniScroll = function (collection, options) {
     this.collection = collection;
 
     this.options = _.defaults(options || {}, {
-
       // Element populated with collection items. Must already be in DOM.
       // We look to see if the bottom of this element is in the scroll view (or close to it).
       contentEl: $(window),
 
       // name of GET parameters
-      pageSizeParam: '_limit',
-      offsetParam: '_skip',
+      pageSizeParam: "_limit",
+      offsetParam: "_skip",
       pageParam: null,
 
       // extra GET params used when collection.fetch is called
       extraParams: {},
-      getParams: function() {},
+      getParams: function () {},
 
       // How many items should be fetched per page
       // Used internally to determine when fetching of pages is completed.
@@ -48,16 +55,15 @@
       // Ideally each response has a field like 'has_more' to indicate if there's another page.
       // Otherwise you could see if resp length < page size if responses should be constant.
       // Otherwise you could do an extra response and then return false here when length is 0.
-      hasMoreFn: function(collection, resp, options) {
+      hasMoreFn: function (collection, resp, options) {
         return resp.has_more;
-      }
+      },
     });
 
     this.initialize.apply(this, arguments);
   };
 
   _.extend(Backbone.InfiniScroll.prototype, Backbone.Events, {
-
     // flag to help us avoid checking scroll position when we know we've already
     // fetched enough objects to fill the viewport.
     // flag to make sure we only have one infiniscroll ajax request out at a time
@@ -75,62 +81,67 @@
     // Should we fetch results when user scrolls to the bottom of the page?
     fetchEnabled: null,
 
-    initialize: function() {
-      _.bindAll(this, 'onScroll', 'onResize', 'fetchSuccess');
+    initialize: function () {
+      _.bindAll(this, "onScroll", "onResize", "fetchSuccess");
       this.$contentEl = $(this.options.contentEl);
-      if (!this.$contentEl.length || !jQuery.contains(document.documentElement, this.$contentEl[0])) {
+      if (
+        !this.$contentEl.length ||
+        !jQuery.contains(document.documentElement, this.$contentEl[0])
+      ) {
         //throw new Error('contentEl must already be in DOM');
-        console.warn('infiniScroll initialized with contentEl not in DOM');
+        console.warn("infiniScroll initialized with contentEl not in DOM");
         return;
       }
       var scrollParent = this.$contentEl.scrollParent();
       this.setScrollEl(scrollParent.is(document) ? $(window) : scrollParent);
       this.reset();
-      this.listenTo(this.collection, 'reset', this.reset);
-      this.listenTo(this.collection, 'sync', this.onSync);
-      $(window).on('resize', this.onResize);
+      this.listenTo(this.collection, "reset", this.reset);
+      this.listenTo(this.collection, "sync", this.onSync);
+      $(window).on("resize", this.onResize);
     },
 
-    setScrollEl: function(el) {
+    setScrollEl: function (el) {
       if (!el) {
-          console.warn('setScrollEl got null');
-          return;
+        console.warn("setScrollEl got null");
+        return;
       }
-      if (this.$scrollEl) this.$scrollEl.off('scroll', this.onScroll);
+      if (this.$scrollEl) this.$scrollEl.off("scroll", this.onScroll);
       this.$scrollEl = el;
       this.scrollElHeight = this.$scrollEl.height();
-      this.$scrollEl.on('scroll', this.onScroll);
+      this.$scrollEl.on("scroll", this.onScroll);
     },
 
-    reset: function() {
+    reset: function () {
       this.page = 1;
       this.prevScrollY = 0;
       this.pendingXhr = false;
       this.enableFetch();
     },
 
-    destroy: function() {
+    destroy: function () {
       this.$contentEl = null;
       if (this.$scrollEl) {
-          this.$scrollEl.off('scroll', this.onScroll);
-          this.$scrollEl = null;
+        this.$scrollEl.off("scroll", this.onScroll);
+        this.$scrollEl = null;
       }
       this.stopListening(this.collection);
-      $(window).off('resize', this.onResize);
+      $(window).off("resize", this.onResize);
     },
 
-    onResize: _.debounce(function() {
-      if (!this.$scrollEl) { return; }
+    onResize: _.debounce(function () {
+      if (!this.$scrollEl) {
+        return;
+      }
       this.prevScrollY = 0;
       this.scrollElHeight = this.$scrollEl.height();
       this.onScroll();
     }, 300),
 
-    enableFetch: function() {
+    enableFetch: function () {
       this.fetchEnabled = true;
     },
 
-    disableFetch: function() {
+    disableFetch: function () {
       //console.log('disabling fetch');
       this.fetchEnabled = false;
     },
@@ -140,42 +151,47 @@
     // Includes both cases:
     // 1) content is too short to fill scrollEl viewport
     // 2) content extends beyond scrollEl viewport and scroll has reached near the end of the content
-    needsMoreContent: function() {
+    needsMoreContent: function () {
       if (!this.$contentEl || !this.$contentEl.length) return;
       var contentEl = this.$contentEl[0];
       var bottomOfContent = contentEl.offsetTop + contentEl.offsetHeight; // y pos inside scrollable
-      var bottomOfScrollViewport = this.$scrollEl.scrollTop() + this.scrollElHeight; // y pos: how far scrolled + viewport height
-      var needsMore = bottomOfContent < bottomOfScrollViewport + this.options.scrollBuffer;
+      var bottomOfScrollViewport =
+        this.$scrollEl.scrollTop() + this.scrollElHeight; // y pos: how far scrolled + viewport height
+      var needsMore =
+        bottomOfContent < bottomOfScrollViewport + this.options.scrollBuffer;
       //console.log('bottomOfContent=%o, bottomOfScrollViewport=%o, combined=%o, needsMore=%o', bottomOfContent, bottomOfScrollViewport, bottomOfScrollViewport + this.options.scrollBuffer, needsMore);
       return needsMore;
     },
 
-    onSync: function(obj, resp, options) {
+    onSync: function (obj, resp, options) {
       if (!(obj instanceof Backbone.Collection)) return; // only care about collection-level sync events
 
       if (!this.fetchEnabled) return;
 
       // If we know there's no more pages/items, stop fetching on scroll
       if (!this.options.hasMoreFn(obj, resp, options)) {
-          this.disableFetch();
-          return;
+        this.disableFetch();
+        return;
       }
 
       // Keep loading more content until the viewport is full
       // use setTimeout so pendingXhr has a chance to clear
-      setTimeout(_.bind(function() {
+      setTimeout(
+        _.bind(function () {
           if (!this.pendingXhr && this.needsMoreContent()) {
-              this.fetch();
+            this.fetch();
           }
-      }, this), 1);
+        }, this),
+        1
+      );
     },
 
-    fetchSuccess: function(collection, response) {
+    fetchSuccess: function (collection, response) {
       this.page += 1;
       // TODO trigger event?
     },
 
-    onScroll: function() {
+    onScroll: function () {
       if (this.pendingXhr || !this.fetchEnabled) return;
 
       // pixels from top of scrollable content to bottom edge of visible/scrolled content
@@ -193,25 +209,29 @@
       if (this.needsMoreContent()) this.fetch();
     },
 
-    fetch: function() {
-      var data = _.extend(this.getPaginationParams(), this.options.extraParams, this.options.getParams());
+    fetch: function () {
+      var data = _.extend(
+        this.getPaginationParams(),
+        this.options.extraParams,
+        this.options.getParams()
+      );
       this.pendingXhr = this.collection.fetch({
         success: this.fetchSuccess,
         remove: false,
-        data: data
+        data: data,
       });
 
       // clear this.pendingXhr whenever the request is done
       if (this.pendingXhr) {
-          this.pendingXhr.always(() => this.pendingXhr = false);
+        this.pendingXhr.always(() => (this.pendingXhr = false));
       }
     },
 
-    getPaginationParams: function() {
+    getPaginationParams: function () {
       var params = {};
 
       if (this.options.pageSizeParam) {
-        params[this.options.pageSizeParam] = this.options.pageSize
+        params[this.options.pageSizeParam] = this.options.pageSize;
       }
 
       if (this.options.pageParam) {
@@ -223,8 +243,7 @@
       }
 
       return params;
-    }
-
+    },
   });
 
   return Backbone.InfiniScroll;

--- a/lib/infiniScroll.js
+++ b/lib/infiniScroll.js
@@ -153,7 +153,7 @@
     // 2) content extends beyond scrollEl viewport and scroll has reached near the end of the content
     needsMoreContent: function () {
       if (!this.$contentEl || !this.$contentEl.length) return;
-      var contentEl = this.$contentEl[0];
+      const contentEl = this.$contentEl[0];
 
       const { offsetTop, offsetHeight, offsetWidth } = contentEl;
 
@@ -162,10 +162,10 @@
         return;
       }
 
-      var bottomOfContent = contentEl.offsetTop + contentEl.offsetHeight; // y pos inside scrollable
-      var bottomOfScrollViewport =
+      const bottomOfContent = contentEl.offsetTop + contentEl.offsetHeight; // y pos inside scrollable
+      const bottomOfScrollViewport =
         this.$scrollEl.scrollTop() + this.scrollElHeight; // y pos: how far scrolled + viewport height
-      var needsMore =
+      const needsMore =
         bottomOfContent < bottomOfScrollViewport + this.options.scrollBuffer;
       //console.log('bottomOfContent=%o, bottomOfScrollViewport=%o, combined=%o, needsMore=%o', bottomOfContent, bottomOfScrollViewport, bottomOfScrollViewport + this.options.scrollBuffer, needsMore);
       return needsMore;

--- a/lib/infiniScroll.js
+++ b/lib/infiniScroll.js
@@ -154,6 +154,14 @@
     needsMoreContent: function () {
       if (!this.$contentEl || !this.$contentEl.length) return;
       var contentEl = this.$contentEl[0];
+
+      const { offsetTop, offsetHeight, offsetWidth } = contentEl;
+
+      // content has no dimensions and is likely hidden
+      if (offsetHeight === 0 && offsetWidth === 0) {
+        return;
+      }
+
       var bottomOfContent = contentEl.offsetTop + contentEl.offsetHeight; // y pos inside scrollable
       var bottomOfScrollViewport =
         this.$scrollEl.scrollTop() + this.scrollElHeight; // y pos: how far scrolled + viewport height

--- a/lib/infiniScroll.js
+++ b/lib/infiniScroll.js
@@ -1,27 +1,27 @@
 (function () {
-  "use strict";
+  'use strict';
 
   // https://github.com/slindberg/jquery-scrollparent/blob/master/jquery.scrollparent.js
   if (!jQuery.fn.scrollParent) {
     jQuery.fn.scrollParent = function () {
       var overflowRegex = /(auto|scroll)/,
-        position = this.css("position"),
-        excludeStaticParent = position === "absolute",
+        position = this.css('position'),
+        excludeStaticParent = position === 'absolute',
         scrollParent = this.parents()
           .filter(function () {
             var parent = $(this);
-            if (excludeStaticParent && parent.css("position") === "static") {
+            if (excludeStaticParent && parent.css('position') === 'static') {
               return false;
             }
             return overflowRegex.test(
-              parent.css("overflow") +
-                parent.css("overflow-y") +
-                parent.css("overflow-x")
+              parent.css('overflow') +
+                parent.css('overflow-y') +
+                parent.css('overflow-x'),
             );
           })
           .eq(0);
 
-      return position === "fixed" || !scrollParent.length
+      return position === 'fixed' || !scrollParent.length
         ? $(this[0].ownerDocument || document)
         : scrollParent;
     };
@@ -36,8 +36,8 @@
       contentEl: $(window),
 
       // name of GET parameters
-      pageSizeParam: "_limit",
-      offsetParam: "_skip",
+      pageSizeParam: '_limit',
+      offsetParam: '_skip',
       pageParam: null,
 
       // extra GET params used when collection.fetch is called
@@ -82,33 +82,33 @@
     fetchEnabled: null,
 
     initialize: function () {
-      _.bindAll(this, "onScroll", "onResize", "fetchSuccess");
+      _.bindAll(this, 'onScroll', 'onResize', 'fetchSuccess');
       this.$contentEl = $(this.options.contentEl);
       if (
         !this.$contentEl.length ||
         !jQuery.contains(document.documentElement, this.$contentEl[0])
       ) {
         //throw new Error('contentEl must already be in DOM');
-        console.warn("infiniScroll initialized with contentEl not in DOM");
+        console.warn('infiniScroll initialized with contentEl not in DOM');
         return;
       }
       var scrollParent = this.$contentEl.scrollParent();
       this.setScrollEl(scrollParent.is(document) ? $(window) : scrollParent);
       this.reset();
-      this.listenTo(this.collection, "reset", this.reset);
-      this.listenTo(this.collection, "sync", this.onSync);
-      $(window).on("resize", this.onResize);
+      this.listenTo(this.collection, 'reset', this.reset);
+      this.listenTo(this.collection, 'sync', this.onSync);
+      $(window).on('resize', this.onResize);
     },
 
     setScrollEl: function (el) {
       if (!el) {
-        console.warn("setScrollEl got null");
+        console.warn('setScrollEl got null');
         return;
       }
-      if (this.$scrollEl) this.$scrollEl.off("scroll", this.onScroll);
+      if (this.$scrollEl) this.$scrollEl.off('scroll', this.onScroll);
       this.$scrollEl = el;
       this.scrollElHeight = this.$scrollEl.height();
-      this.$scrollEl.on("scroll", this.onScroll);
+      this.$scrollEl.on('scroll', this.onScroll);
     },
 
     reset: function () {
@@ -121,11 +121,11 @@
     destroy: function () {
       this.$contentEl = null;
       if (this.$scrollEl) {
-        this.$scrollEl.off("scroll", this.onScroll);
+        this.$scrollEl.off('scroll', this.onScroll);
         this.$scrollEl = null;
       }
       this.stopListening(this.collection);
-      $(window).off("resize", this.onResize);
+      $(window).off('resize', this.onResize);
     },
 
     onResize: _.debounce(function () {
@@ -190,7 +190,7 @@
             this.fetch();
           }
         }, this),
-        1
+        1,
       );
     },
 
@@ -221,7 +221,7 @@
       var data = _.extend(
         this.getPaginationParams(),
         this.options.extraParams,
-        this.options.getParams()
+        this.options.getParams(),
       );
       this.pendingXhr = this.collection.fetch({
         success: this.fetchSuccess,


### PR DESCRIPTION
This accounts for the use case where the scroll container might be initialized while not visible. Previously, `needsMoreContent` would always return true and the plugin would recursively fetch all available items regardless of pagination limit.

Now, we only fetch more if the scroll container actually has dimensions.